### PR TITLE
Remove unused `authors` CSS class

### DIFF
--- a/app/assets/stylesheets/layout/_layout.scss
+++ b/app/assets/stylesheets/layout/_layout.scss
@@ -40,13 +40,6 @@ body {
     padding: 3em;
   }
 
-  .authors {
-    a {
-      color: $base-font-color;
-      font-size: 1.8em;
-    }
-  }
-
   .author {
     p {
       margin-bottom: 40px;


### PR DESCRIPTION
I was looking into unifying the styling of the author and list pages and
noticed this class is never used.