### PR TITLE
Display covers books on lists pages

### DIFF
--- a/app/assets/stylesheets/layout/_default_list.scss
+++ b/app/assets/stylesheets/layout/_default_list.scss
@@ -1,15 +1,16 @@
-.default-list {
+.authors-index,
+.lists-index {
   $base-border-radius: 3px !default;
   $base-spacing: 1.5em !default;
-  $default-list-image-width: 150px;
-  $default-list-color: $base-font-color;
+  $inline-books-image-width: 150px;
+  $inline-books-color: $base-font-color;
 
-  border-bottom: 1px solid transparentize($default-list-color, 0.9);
+  border-bottom: 1px solid transparentize($inline-books-color, 0.9);
   margin-bottom: $base-spacing;
   padding-bottom: 1em;
   width: 100%;
 
-  ul {
+  ul.books {
     width: 100%;
 
     li {
@@ -21,12 +22,12 @@
       border-radius: $base-border-radius;
       height: auto;
       max-width: none;
-      width: $default-list-image-width;
+      width: $inline-books-image-width;
     }
 
     a {
       height: auto;
-      width: $default-list-image-width;
+      width: $inline-books-image-width;
       display: block;
       border-bottom: 3px solid $white;
     }

--- a/app/assets/stylesheets/layout/_default_list.scss
+++ b/app/assets/stylesheets/layout/_default_list.scss
@@ -1,10 +1,10 @@
-.authors-list {
+.default-list {
   $base-border-radius: 3px !default;
   $base-spacing: 1.5em !default;
-  $authors-list-image-width: 150px;
-  $authors-list-color: $base-font-color;
+  $default-list-image-width: 150px;
+  $default-list-color: $base-font-color;
 
-  border-bottom: 1px solid transparentize($authors-list-color, 0.9);
+  border-bottom: 1px solid transparentize($default-list-color, 0.9);
   margin-bottom: $base-spacing;
   padding-bottom: 1em;
   width: 100%;
@@ -21,13 +21,14 @@
       border-radius: $base-border-radius;
       height: auto;
       max-width: none;
-      width: $authors-list-image-width;
+      width: $default-list-image-width;
     }
 
     a {
       height: auto;
-      width: $authors-list-image-width;
+      width: $default-list-image-width;
       display: block;
+      border-bottom: 3px solid $white;
     }
 
     a:hover {

--- a/app/views/authors/index.html.erb
+++ b/app/views/authors/index.html.erb
@@ -2,8 +2,8 @@
 
 <% if authors.any? %>
   <% authors.each do |author| %>
-  <div class="authors-list">
-    <h2><%= link_to author.name, author %></h1>
+  <div class="default-list">
+    <h2><%= link_to author.name, author %></h2>
     <ul>
       <% author.popular_books.each do |book| %>
         <li><%= link_to image_tag(book.sample_cover), book %></li>

--- a/app/views/authors/index.html.erb
+++ b/app/views/authors/index.html.erb
@@ -2,14 +2,12 @@
 
 <% if authors.any? %>
   <% authors.each do |author| %>
-  <div class="default-list">
-    <h2><%= link_to author.name, author %></h2>
-    <ul>
-      <% author.popular_books.each do |book| %>
-        <li><%= link_to image_tag(book.sample_cover), book %></li>
-      <% end %>
-    </ul>
-  </div>
+  <h2><%= link_to author.name, author %></h2>
+  <ul class="books">
+    <% author.popular_books.each do |book| %>
+      <li><%= link_to image_tag(book.sample_cover), book %></li>
+    <% end %>
+  </ul>
   <% end %>
 <% else %>
   <h1><%= t(".no_authors_found") %></h1>

--- a/app/views/lists/_list.html.erb
+++ b/app/views/lists/_list.html.erb
@@ -1,12 +1,12 @@
-<li class="list">
+<div class="default-list">
   <h2><%= link_to list.name, list %></h2>
   <% if list.empty? %>
-    <%= t(".empty") %>
+    <p><%= t(".empty") %></p>
   <% else %>
-    <ul class="books">
+    <ul>
       <% list.highlights(maximum: 5).each do |book| %>
-        <li class="book"><%= link_to book.title %></li>
+        <li><%= link_to image_tag(book.sample_cover), book %></li>
       <% end %>
     </ul>
   <% end %>
-</li>
+</div>

--- a/app/views/lists/_list.html.erb
+++ b/app/views/lists/_list.html.erb
@@ -1,12 +1,10 @@
-<div class="default-list">
-  <h2><%= link_to list.name, list %></h2>
-  <% if list.empty? %>
-    <p><%= t(".empty") %></p>
-  <% else %>
-    <ul>
-      <% list.highlights(maximum: 5).each do |book| %>
-        <li><%= link_to image_tag(book.sample_cover), book %></li>
-      <% end %>
-    </ul>
-  <% end %>
-</div>
+<h2><%= link_to list.name, list %></h2>
+<% if list.empty? %>
+  <p><%= t(".empty") %></p>
+<% else %>
+  <ul class="books">
+    <% list.highlights(maximum: 5).each do |book| %>
+      <li><%= link_to image_tag(book.sample_cover), book %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
 
   lists:
     list:
-      empty: We don't have any curated list yet.
+      empty: We haven't added any book yet.
     show:
       empty: This list is empty.
     index:

--- a/spec/features/show_all_of_the_lists_of_books_spec.rb
+++ b/spec/features/show_all_of_the_lists_of_books_spec.rb
@@ -26,6 +26,6 @@ RSpec.describe "Shows all of the lists of books", type: :feature do
   end
 
   def have_list(name)
-    have_css(".default-list h2", text: name)
+    have_css(".lists-index h2", text: name)
   end
 end

--- a/spec/features/show_all_of_the_lists_of_books_spec.rb
+++ b/spec/features/show_all_of_the_lists_of_books_spec.rb
@@ -13,24 +13,19 @@ RSpec.describe "Shows all of the lists of books", type: :feature do
 
   scenario "books within a list" do
     best_fantasy = create(:list, name: "Best Fantasy")
-    fellowship = create(:book, title: "The Fellowship of the Ring")
-    two_towers = create(:book, title: "The Two Towers")
+    fellowship = create(:book, cover: "http://cov.er/fellowship_ring.jpg")
+    two_towers = create(:book, cover: "http://cov.er/two_towers.jpg")
     create(:list_entry, list: best_fantasy, book: fellowship)
     create(:list_entry, list: best_fantasy, book: two_towers)
 
     visit lists_path
 
-    entries = list_entries("Best Fantasy")
-    expect(entries).to include("The Fellowship of the Ring")
-    expect(entries).to include("The Two Towers")
-  end
-
-  def list_entries(list_name)
-    list = find("li", text: list_name)
-    list.all("li").map(&:text)
+    expect(page).to have_list("Best Fantasy")
+    expect(page).to have_book_cover("http://cov.er/fellowship_ring.jpg")
+    expect(page).to have_book_cover("http://cov.er/two_towers.jpg")
   end
 
   def have_list(name)
-    have_css(".lists li", text: name)
+    have_css(".default-list h2", text: name)
   end
 end

--- a/spec/features/view_list_of_authors_spec.rb
+++ b/spec/features/view_list_of_authors_spec.rb
@@ -22,6 +22,6 @@ RSpec.feature "View list of Authors", type: :feature do
   end
 
   def have_author(name)
-    have_css(".authors-list h2", text: name)
+    have_css(".default-list h2", text: name)
   end
 end

--- a/spec/features/view_list_of_authors_spec.rb
+++ b/spec/features/view_list_of_authors_spec.rb
@@ -22,6 +22,6 @@ RSpec.feature "View list of Authors", type: :feature do
   end
 
   def have_author(name)
-    have_css(".default-list h2", text: name)
+    have_css(".authors-index h2", text: name)
   end
 end

--- a/spec/views/lists/_list.html.erb_spec.rb
+++ b/spec/views/lists/_list.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "lists/_list" do
 
       render template: "lists/_list", locals: { list: list }
 
-      expect(rendered).to have_css(".default-list ul li")
+      expect(rendered).to have_css("ul.books li")
     end
   end
 end

--- a/spec/views/lists/_list.html.erb_spec.rb
+++ b/spec/views/lists/_list.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "lists/_list" do
 
       render template: "lists/_list", locals: { list: list }
 
-      expect(rendered).to have_css("li", text: t(".list.empty"))
+      expect(rendered).to have_css("p", text: t(".list.empty"))
     end
   end
 
@@ -22,7 +22,7 @@ RSpec.describe "lists/_list" do
 
       render template: "lists/_list", locals: { list: list }
 
-      expect(rendered).to have_css("ul.books li")
+      expect(rendered).to have_css(".default-list ul li")
     end
   end
 end

--- a/spec/views/lists/index.html.erb_spec.rb
+++ b/spec/views/lists/index.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "lists/index" do
 
       render template: "lists/index", locals: { lists: lists }
 
-      expect(rendered).to have_css("ul.lists li.list")
+      expect(rendered).to have_css(".default-list h2")
     end
   end
 

--- a/spec/views/lists/index.html.erb_spec.rb
+++ b/spec/views/lists/index.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "lists/index" do
 
       render template: "lists/index", locals: { lists: lists }
 
-      expect(rendered).to have_css(".default-list h2")
+      expect(rendered).to have_css("ul.lists h2")
     end
   end
 


### PR DESCRIPTION
Displaying books cover on index list page.

Close the card:
https://trello.com/c/i8aDsArd/10-displays-the-list-title-and-5-10-book-cover-images-for-each-list