### PR TITLE
Remove "Create Account" link for signed-in users

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def logged_out?
+    !current_user.present?
+  end
 end

--- a/app/views/books/_reviews.html.erb
+++ b/app/views/books/_reviews.html.erb
@@ -3,7 +3,7 @@
 </div>
 <% if review_policy.authorized_for_review? %>
   <%= render partial: "reviews/form", locals: { book: book, review: Review.new } %>
-<% else %>
+<% elsif logged_out? %>
   <%= link_to t("books.reviews.create_account"), new_registration_path %>
 <% end %>
 <%= render book.reviews %>


### PR DESCRIPTION
This resolves a bug due to the same message being shown to guests and to
users who had already written a review. The new behaviour simply hides
the form once the user has left a review.